### PR TITLE
chore: avoid shipping devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,7 @@
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^2.7.1",
     "@graphql-codegen/visitor-plugin-common": "^2.12.2",
-    "@typescript-eslint/eslint-plugin": "^5.42.1",
-    "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.14",
-    "eslint": "^8.27.0",
-    "tslib": "~2.4.0"
+    "change-case-all": "^1.0.14"
   },
   "main": "dist/cjs/src/index.js",
   "module": "dist/esnext/src/index.js",
@@ -58,8 +54,10 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",
     "@types/jest": "^29.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "babel-jest": "^29.2.1",
+    "eslint": "^8.27.0",
     "eslint-plugin-import": "^2.26.0",
     "graphql": "^14.7.0",
     "jest": "^29.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,7 +2378,6 @@ __metadata:
     "@types/jest": ^29.2.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
-    auto-bind: ~4.0.0
     babel-jest: ^29.2.1
     change-case-all: ^1.0.14
     eslint: ^8.27.0
@@ -2386,7 +2385,6 @@ __metadata:
     graphql: ^14.7.0
     jest: ^29.2.1
     ts-jest: ^29.0.3
-    tslib: ~2.4.0
     typescript: ^4.8.4
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0


### PR DESCRIPTION
# Summary

Consuming applications are getting a newer version of eslint and that is causing issues.