### PR TITLE
Handle lowercase fragment names correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asa-graphql-ts-typed-document",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "POC graphql-code-generator plugin for typed documents. Forked from https://github.com/dotansimha/graphql-code-generator",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export const plugin: PluginFunction<TypeScriptDocumentNodesVisitorPluginConfig> 
   const visitor = new TypeScriptDocumentNodesVisitor(schema, allFragments, config, documents);
   const visitorResult = oldVisit(allAst, { leave: visitor });
   const nameMapper = (name: string) => {
-    return name + visitor.getFragmentSuffix(name);
+    return visitor.convertName(name) + visitor.getFragmentSuffix(name);
   };
 
   return {

--- a/tests/typed-document-node.spec.ts
+++ b/tests/typed-document-node.spec.ts
@@ -184,6 +184,44 @@ describe('TypedDocumentNode', () => {
     expect(res.prepend).toContain(`import { JobFragmentFragment } from './_fragment.graphql';`);
   });
 
+  it('Should work with lowercase fragment imports via fragmentImportsSourceMap', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      schema {
+        query: Query
+      }
+
+      type Query {
+        jobs: [Job!]!
+      }
+
+      type Job {
+        id: ID!
+        recruiterName: String!
+        title: String!
+      }
+    `);
+
+    const ast = parse(/* GraphQL */ `
+      #import "./_fragment.graphql"
+      query GetJobs {
+        ...jobFragment
+      }
+    `);
+
+    const res = (await plugin(
+      schema,
+      [ { location: '', document: ast }],
+      {
+        fragmentImportsSourceMap: {
+          jobFragment: './_fragment.graphql'
+        }
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(res.prepend).toContain(`import { JobFragmentFragment } from './_fragment.graphql';`);
+  });
+
   it('Should not duplicate imports for the same fragment used twice from fragmentImportsSourceMap', async () => {
     const schema = buildSchema(/* GraphQL */ `
       schema {


### PR DESCRIPTION
Use the `convertName` function to ensure the imported name matches the compiled type name.