### PR TITLE
feat: publish as an esm module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # asa-graphql-ts-typed-document
 
-## 2.0.0 
+## 3.0.0
+
+- flips the switch and makes this library an esm library by default
+
+## 2.0.0
 
 - work with the graphql@16.6.0 visitor logic.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "asa-graphql-ts-typed-document",
-  "version": "2.0.2",
+  "version": "3.0.0",
+  "type": "module",
   "description": "POC graphql-code-generator plugin for typed documents. Forked from https://github.com/dotansimha/graphql-code-generator",
   "repository": {
     "type": "git",

--- a/tests/typed-document-node.spec.ts
+++ b/tests/typed-document-node.spec.ts
@@ -1,6 +1,6 @@
 import { Types } from '@graphql-codegen/plugin-helpers';
 import { buildSchema, parse } from 'graphql';
-import { plugin } from '../src';
+import { plugin } from '../src/index.js';
 import * as ts from 'typescript';
 
 function findAncestor(node: ts.Node, visitor: (n: ts.Node) => boolean) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "target": "es2018",
     "lib": ["es6", "esnext", "es2015", "dom"],
     "suppressImplicitAnyIndexErrors": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "emitDecoratorMetadata": true,
     "sourceMap": true,
     "declaration": true,
@@ -25,5 +25,10 @@
     "paths": {}
   },
   "include": ["src", "tests"],
-  "exclude": ["**/tests/test-files", "**/tests/test-documents", "**/dist", "**/temp"]
+  "exclude": [
+    "**/tests/test-files",
+    "**/tests/test-documents",
+    "**/dist",
+    "**/temp"
+  ]
 }


### PR DESCRIPTION
# Summary

When trying to consume this as an esm module we get the following error

<img width="1062" alt="Screenshot 2023-03-28 at 10 18 27 AM" src="https://user-images.githubusercontent.com/1854811/228323949-3f5f7d75-7533-4e48-8643-1a0ea42c588b.png">

When we change the type to be a module it works as expected. I updated tsconfig to ensure the paths have the .js extension as shown in changing the test file.