### PR TITLE
chore: revert module type, downstream consumers can not pick library type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # asa-graphql-ts-typed-document
 
+## 4.0.0
+
+- downstream consumers can't pick which to pick, removing type: module.
+
 ## 3.0.0
 
 - flips the switch and makes this library an esm library by default

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "asa-graphql-ts-typed-document",
-  "version": "3.0.0",
-  "type": "module",
+  "version": "4.0.0",
   "description": "POC graphql-code-generator plugin for typed documents. Forked from https://github.com/dotansimha/graphql-code-generator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Downstream consumers are forced to ESM, removing type module will help resolve this issue.

<img width="1108" alt="Screenshot 2023-06-06 at 10 19 19 AM" src="https://github.com/asa-graphql-codegen/asa-graphql-ts-typed-document/assets/1854811/cc0a7cbd-1a1e-42b1-87da-e551c0f38852">
